### PR TITLE
Add Maven build and CDate tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ Sous Windows 7 64 bits
  - PostgreSQL 9.4.1-3 x64
  - StockSemence.jar (obtenu après compilation des sources, non disponible au moment de la première publication github)
  - scripts d'installation sur BDD (contenus dans le dossier postgres)
+
+## Tests
+
+Ce projet utilise Maven pour lancer les tests unitaires.
+Vous pouvez exécuter les tests avec :
+
+```bash
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,33 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>StockSemences</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <build>
+        <sourceDirectory>src</sourceDirectory>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/src/CDate.java
+++ b/src/CDate.java
@@ -17,9 +17,9 @@ public class CDate extends GregorianCalendar
 	public CDate(int p_jour, int p_mois, int p_annee)
 	{
 		// TODO ajout de contrôles de validité de date
-		this.set(Calendar.DAY_OF_MONTH, p_jour);
-		this.set(Calendar.MONTH,        p_mois);
-		this.set(Calendar.YEAR,         p_annee);				
+                this.set(Calendar.DAY_OF_MONTH, p_jour);
+                this.set(Calendar.MONTH,        p_mois-1);
+                this.set(Calendar.YEAR,         p_annee);
 	}
 	
 	public CDate(Calendar p_calendar) 
@@ -34,10 +34,10 @@ public class CDate extends GregorianCalendar
 
 	public void init()
 	{
-		// initialisation au 01/01/2000
-		this.set(Calendar.DAY_OF_MONTH, 1);
-		this.set(Calendar.MONTH,        1);
-		this.set(Calendar.YEAR,      2000);		
+                // initialisation au 01/01/2000
+                this.set(Calendar.DAY_OF_MONTH, 1);
+                this.set(Calendar.MONTH,        0);
+                this.set(Calendar.YEAR,      2000);
 	}
 
 	public void init_calendar(Calendar p_calendar)

--- a/src/test/java/CDateTest.java
+++ b/src/test/java/CDateTest.java
@@ -1,0 +1,14 @@
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class CDateTest {
+    @Test
+    public void defaultConstructorReturns20000101() {
+        assertEquals(20000101L, new CDate().get_bigint());
+    }
+
+    @Test
+    public void constructorWithArgsReturns20000101() {
+        assertEquals(20000101L, new CDate(1, 1, 2000).get_bigint());
+    }
+}


### PR DESCRIPTION
## Summary
- fix month handling in `CDate`
- add Maven project and JUnit test folder
- provide a unit test for `CDate`
- document running tests with Maven

## Testing
- `javac -cp /usr/share/java/junit4.jar src/CDate.java src/test/java/CDateTest.java && java -cp /usr/share/java/junit4.jar:src:src/test/java org.junit.runner.JUnitCore CDateTest`

------
https://chatgpt.com/codex/tasks/task_e_684bd245ef58832d90f6a5b23e1e8b63