### PR TITLE
Add date validation in CDate

### DIFF
--- a/src/CDate.java
+++ b/src/CDate.java
@@ -16,9 +16,23 @@ public class CDate extends GregorianCalendar
 
        public CDate(int p_jour, int p_mois, int p_annee)
        {
-               // TODO ajout de contrôles de validité de date
+               if (p_annee <= 0)
+               {
+                       throw new IllegalArgumentException("Invalid year: " + p_annee);
+               }
+
                if (p_mois < 1 || p_mois > 12)
+               {
                        throw new IllegalArgumentException("Invalid month: " + p_mois);
+               }
+
+               int l_max_jour = new GregorianCalendar(p_annee, p_mois - 1, 1).getActualMaximum(Calendar.DAY_OF_MONTH);
+
+               if (p_jour < 1 || p_jour > l_max_jour)
+               {
+                       throw new IllegalArgumentException("Invalid day: " + p_jour + " for month " + p_mois + " and year " + p_annee);
+               }
+
                this.set(Calendar.DAY_OF_MONTH, p_jour);
                this.set(Calendar.MONTH,        p_mois-1);
                this.set(Calendar.YEAR,         p_annee);

--- a/src/test/java/CDateTest.java
+++ b/src/test/java/CDateTest.java
@@ -11,4 +11,19 @@ public class CDateTest {
     public void constructorWithArgsReturns20000101() {
         assertEquals(20000101L, new CDate(1, 1, 2000).get_bigint());
     }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorThrowsOnInvalidMonth() {
+        new CDate(1, 13, 2000);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorThrowsOnInvalidDay() {
+        new CDate(31, 2, 2001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void constructorThrowsOnNegativeYear() {
+        new CDate(1, 1, 0);
+    }
 }


### PR DESCRIPTION
## Summary
- validate year and day ranges in `CDate`
- test invalid days, months and year

## Testing
- `mvn test` *(fails: Could not download maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6872747b1164832d96d22fdd68983b73